### PR TITLE
issue-156: Добавлено контекстное меню в форму ошибок

### DIFF
--- a/src/main/java/com/github/otymko/phoenixbsl/gui/stage/IssuesStage.java
+++ b/src/main/java/com/github/otymko/phoenixbsl/gui/stage/IssuesStage.java
@@ -183,10 +183,10 @@ public class IssuesStage extends Stage {
   }
 
   private ContextMenu createTreeContextMenu() {
-    MenuItem openStandardItem = new MenuItem("Открыть стандарт");
+    MenuItem openStandardItem = new MenuItem("Открыть диагностику");
     openStandardItem.setOnAction(this::openStandard);
 
-    MenuItem copyStandardItem = new MenuItem("Скопировать ссылку на стандарт");
+    MenuItem copyStandardItem = new MenuItem("Скопировать ссылку на диагностику");
     copyStandardItem.setOnAction(this::copyStandardLink);
 
     ContextMenu menu = new ContextMenu();


### PR DESCRIPTION
Добавлено контекстное меню в форму ошибок с пунктами:
- Открыть диагностику - открывает стандарт в браузере.
- Скопировать ссылку на диагностику - копирует ссылку на стандарт в буфер обмена, используется для случаев, когда программа установлена на ферме без доступа к интернету.